### PR TITLE
jmc_atv_grey corrected to jmc_atv_gray

### DIFF
--- a/empty.deerisle/cfgspawnabletypes.xml
+++ b/empty.deerisle/cfgspawnabletypes.xml
@@ -3903,7 +3903,7 @@
 			<item name="HeadlightH7" chance="0.75" />
 		</attachments>
 	</type>	
-	<type name="jmc_atv_Grey">
+	<type name="jmc_atv_Gray">
 		<attachments chance="1.00">
 			<item name="jmc_atv_Wheel" chance="0.90" />
 		</attachments>

--- a/empty.deerisle/db/events.xml
+++ b/empty.deerisle/db/events.xml
@@ -1284,7 +1284,7 @@
         <limit>mixed</limit>
         <active>1</active>
         <children>
-            <child lootmax="0" lootmin="0" max="5" min="3" type="jmc_atv_Grey"/>            
+            <child lootmax="0" lootmin="0" max="5" min="3" type="jmc_atv_Gray"/>
         </children>
     </event>
 	<event name="VehicleATVCivil">

--- a/empty.deerisle/db/types.xml
+++ b/empty.deerisle/db/types.xml
@@ -26651,7 +26651,7 @@
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
   </type>
-  <type name="jmc_atv_Grey">
+  <type name="jmc_atv_Gray">
     <nominal>0</nominal>
     <lifetime>3888000</lifetime>
     <restock>1800</restock>


### PR DESCRIPTION
Various files had 'jmc_atv_grey' instead of 'jmc_atv_gray' which was causing the event to break. Credit to Dr Leigh for spotting this first.